### PR TITLE
libostree intergration (preparation for command line replacement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ mkdir build
 cd build
 cmake ..
 cmake --build .
-./bin/ostree-log
+./bin/ostree-tui
 ```
 
 **Webassembly build:**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,19 +6,9 @@ add_subdirectory(core)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ../bin)
 add_executable("${PROJECT_NAME}" main.cpp)
 
-# TODO this is dirty: fix & make it work on 'any' system
-include_directories(
-    /usr/include/ostree-1
-    /usr/include/glib-2.0/
-    /usr/lib/x86_64-linux-gnu/glib-2.0/include
-    /usr/lib64/glib-2.0/include/
-)
-
 target_link_libraries(ostree-tui
     PRIVATE ostui::core
     PRIVATE ostui::util
-    PRIVATE ostree-1
-    PRIVATE glib-2.0
     PRIVATE ftxui::screen
     PRIVATE ftxui::dom
     PRIVATE ftxui::component

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -6,11 +6,15 @@ set(ostree-tui_include_dirs "${CMAKE_CURRENT_SOURCE_DIR}")
 add_library(ostree-tui_core STATIC ${ostree_sources})
 
 target_link_libraries(ostree-tui_core
+  PRIVATE clip
   PRIVATE ostui::util
   PRIVATE ftxui::screen
   PRIVATE ftxui::dom
   PRIVATE ftxui::component
-  PRIVATE clip
 )
-target_include_directories(ostree-tui_core PUBLIC ${ostree-tui_include_dirs})
+#target_include_directories(ostree-tui_core
+#  PUBLIC ${ostree-tui_include_dirs}
+#  PUBLIC ../../build/_deps/clip-src
+#)
+
 add_library(ostui::core ALIAS ostree-tui_core)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(ostree-tui_core
 )
 target_include_directories(ostree-tui_core
   PUBLIC ${ostree-tui_include_dirs}
+  # TODO dirty
   PUBLIC ../../build/_deps/clip-src
 )
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,9 +12,9 @@ target_link_libraries(ostree-tui_core
   PRIVATE ftxui::dom
   PRIVATE ftxui::component
 )
-#target_include_directories(ostree-tui_core
-#  PUBLIC ${ostree-tui_include_dirs}
-#  PUBLIC ../../build/_deps/clip-src
-#)
+target_include_directories(ostree-tui_core
+  PUBLIC ${ostree-tui_include_dirs}
+  PUBLIC ../../build/_deps/clip-src
+)
 
 add_library(ostui::core ALIAS ostree-tui_core)

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -38,7 +38,7 @@ auto OSTreeTUI::main(const std::string& repo) -> int {
 	size_t selected_commit{0};
 
 	// new OSTree Repo - TODO replace
-	cpplibostree::OSTreeRepo cpp_ostree_repo("tmp_repo");
+	cpplibostree::OSTreeRepo cpp_ostree_repo(repo);
 	
 	// Screen
 	auto screen = ScreenInteractive::Fullscreen();

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -22,8 +22,11 @@
 #include "manager.h"
 #include "footer.h"
 
+//#include "clip.h"
+
 #include "../util/cl_ostree.h"
 #include "../util/commandline.h"
+//#include "../util/cpplibostree.h"
 
 
 auto OSTreeTUI::main(const std::string& repo) -> int {
@@ -33,6 +36,9 @@ auto OSTreeTUI::main(const std::string& repo) -> int {
 	// OSTree Repo
 	cl_ostree::OSTreeRepo ostree_repo(repo);
 	size_t selected_commit{0};
+
+	// new OSTree Repo - TODO replace
+	//cpplibostree::OSTreeRepo cpp_ostree_repo("tmp_repo");
 	
 	// Screen
 	auto screen = ScreenInteractive::Fullscreen();
@@ -63,8 +69,8 @@ auto OSTreeTUI::main(const std::string& repo) -> int {
 // - FINALIZE ---------- ----------
   	int log_size = 80;
   	int footer_size = 1;
-  	auto container = log_renderer;
-  	container = ResizableSplitRight(manager_renderer, container, &log_size);
+  	auto container = manager_renderer;
+  	container = ResizableSplitLeft(log_renderer, container, &log_size);
   	container = ResizableSplitBottom(footer_renderer, container, &footer_size);
 	
 	// add shortcuts
@@ -78,6 +84,13 @@ auto OSTreeTUI::main(const std::string& repo) -> int {
     	if (event == Event::Character('r')) {
     	  std::cout << "rebase not implemented yet" << std::endl;
     	  return true;
+    	}
+		// copy commit id
+    	if (event == Event::Character('c')) {
+			// TODO replace with (working) clipboard library
+			std::string cmd = "gnome-terminal -- bash -c \"echo " + ostree_repo.getCommitListSorted()->at(selected_commit).hash + " | xclip -selection clipboard; sleep .01\"";
+			commandline::exec(cmd.c_str());
+    	  	return true;
     	}
 		// switch through commits (may be temporary)
     	if (event == Event::Character('+')) {

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -26,7 +26,7 @@
 
 #include "../util/cl_ostree.h"
 #include "../util/commandline.h"
-//#include "../util/cpplibostree.h"
+#include "../util/cpplibostree.h"
 
 
 auto OSTreeTUI::main(const std::string& repo) -> int {
@@ -38,7 +38,7 @@ auto OSTreeTUI::main(const std::string& repo) -> int {
 	size_t selected_commit{0};
 
 	// new OSTree Repo - TODO replace
-	//cpplibostree::OSTreeRepo cpp_ostree_repo("tmp_repo");
+	cpplibostree::OSTreeRepo cpp_ostree_repo("tmp_repo");
 	
 	// Screen
 	auto screen = ScreenInteractive::Fullscreen();

--- a/src/core/commit.cpp
+++ b/src/core/commit.cpp
@@ -91,7 +91,9 @@ auto commitRender(cl_ostree::OSTreeRepo repo, std::vector<Commit> commits, std::
 
 		// render commit
 
-		std::string commit_top_text = "   " + commit.hash.substr(commit.hash.size() - 8);
+		std::string commit_top_text = commit.hash;
+		if (commit_top_text.size() > 8)
+			commit_top_text = "   " + commit.hash.substr(commit.hash.size() - 8);
 		Element commit_top_text_element = text(commit_top_text);
 		// selected
 		if (marked_string.compare(commit.hash) == 0) {

--- a/src/core/footer.cpp
+++ b/src/core/footer.cpp
@@ -15,7 +15,7 @@ Component footer::footerRender() {
 		return hbox({
 			text(" OSTree TUI ") | bold,
 			separator(),
-			text("  || exit: q || navigate commits: +/- ||  "), // || rebase_mode: r || apply changes: s
+			text("  || exit: q || navigate commits: +/- || copy commit hash: c ||  "), // || rebase_mode: r || apply changes: s
 		});
 	});
 }

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -17,5 +17,12 @@ target_link_libraries(util
   PRIVATE clip
 )
 
-target_include_directories(util PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
+#target_include_directories(util
+#  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+#  /usr/include/ostree-1
+#  /usr/include/glib-2.0/
+#  /usr/lib/x86_64-linux-gnu/glib-2.0/include
+#  /usr/lib64/glib-2.0/include/
+#)
+
 add_library(ostui::util ALIAS util)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,28 +1,32 @@
 cmake_minimum_required(VERSION 3.27)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(glib-2.0 REQUIRED IMPORTED_TARGET glib-2.0)
+
 file(GLOB_RECURSE util_sources *.cpp *.h)
 
 add_library(util STATIC ${util_sources})
 
-# TODO this is dirty: fix & make it work on 'any' system
-include_directories(
+# TODO this is dirty: fix & make it work on 'any' system, e.g. PkgConfig
+target_include_directories(util
+    PUBLIC
     /usr/include/ostree-1
-    /usr/include/glib-2.0/
-    /usr/lib/x86_64-linux-gnu/glib-2.0/include
-    /usr/lib64/glib-2.0/include/
-)
-target_link_libraries(util
-  PRIVATE ostree-1
-  PRIVATE glib-2.0
-  PRIVATE clip
+    ${glib-2.0_INCLUDE_DIRS}
+    # includes: /usr/include/glib-2.0/
+    #           /usr/include/glib-2.0/glib
+    #           /usr/include/glib-2.0/gio
+    #           /usr/lib64/glib-2.0/include
+    #/usr/include/sysprof-6
 )
 
-#target_include_directories(util
-#  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-#  /usr/include/ostree-1
-#  /usr/include/glib-2.0/
-#  /usr/lib/x86_64-linux-gnu/glib-2.0/include
-#  /usr/lib64/glib-2.0/include/
-#)
+target_link_libraries(util
+  PUBLIC PkgConfig::glib-2.0
+  # PkgConfig::glib-2.0 not working properly (missing link to gio & gobject)
+  PUBLIC /usr/lib64/libgio-2.0.so
+  PUBLIC /usr/lib64/libgobject-2.0.so
+
+  PRIVATE ostree-1
+  PRIVATE clip
+)
 
 add_library(ostui::util ALIAS util)

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.27)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(glib-2.0 REQUIRED IMPORTED_TARGET glib-2.0)
+pkg_check_modules(ostree-1 REQUIRED IMPORTED_TARGET ostree-1)
 
 file(GLOB_RECURSE util_sources *.cpp *.h)
 
@@ -10,13 +11,12 @@ add_library(util STATIC ${util_sources})
 target_include_directories(util
     PUBLIC
     ${glib-2.0_INCLUDE_DIRS}
-    # TODO this is dirty:
-    /usr/include/ostree-1
+    ${ostree-1_INCLUDE_DIRS}
 )
 
 target_link_libraries(util
   PUBLIC PkgConfig::glib-2.0
-  # PkgConfig::glib-2.0 not working properly -> gio & gobject manually added
+  # PkgConfig::glib-2.0 not including gio & gobject -> manually added
   PUBLIC /usr/lib64/libgio-2.0.so
   PUBLIC /usr/lib64/libgobject-2.0.so
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -7,21 +7,16 @@ file(GLOB_RECURSE util_sources *.cpp *.h)
 
 add_library(util STATIC ${util_sources})
 
-# TODO this is dirty: fix & make it work on 'any' system, e.g. PkgConfig
 target_include_directories(util
     PUBLIC
-    /usr/include/ostree-1
     ${glib-2.0_INCLUDE_DIRS}
-    # includes: /usr/include/glib-2.0/
-    #           /usr/include/glib-2.0/glib
-    #           /usr/include/glib-2.0/gio
-    #           /usr/lib64/glib-2.0/include
-    #/usr/include/sysprof-6
+    # TODO this is dirty:
+    /usr/include/ostree-1
 )
 
 target_link_libraries(util
   PUBLIC PkgConfig::glib-2.0
-  # PkgConfig::glib-2.0 not working properly (missing link to gio & gobject)
+  # PkgConfig::glib-2.0 not working properly -> gio & gobject manually added
   PUBLIC /usr/lib64/libgio-2.0.so
   PUBLIC /usr/lib64/libgobject-2.0.so
 

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -10,7 +10,7 @@
 #include <fcntl.h>
 // external
 #include <ostree.h>
-#include <glib.h>
+#include <glib-2.0/glib.h>
 
 using namespace cpplibostree;
 

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <string>
 #include <iostream>
+#include <vector>
 // C
 #include <cstdio>
 #include <cerrno>
@@ -11,26 +12,109 @@
 // external
 #include <ostree.h>
 #include <glib-2.0/glib.h>
+#include <vector>
 
 using namespace cpplibostree;
 
 OSTreeRepo::OSTreeRepo(std::string repo_path) {
 
-    g_autoptr (GError) error = NULL;
-    OstreeRepo *repo = NULL;
+    // open ostree repository
+    GError *error = NULL;
+    OstreeRepo *repo = ostree_repo_open_at(AT_FDCWD, repo_path.c_str(), NULL, &error);
 
-    g_autoptr (GFile) repo_path_ptr = g_file_new_for_path (repo_path.c_str());
-    g_autoptr (OstreeRepo) ret_repo = ostree_repo_new (repo_path_ptr);
-    if (!ostree_repo_open (ret_repo, NULL, &error))
-        std::cout << "ostree error\n";
+    if (repo == NULL) {
+        g_printerr("Error opening repository: %s\n", error->message);
+        g_error_free(error);
+        // TODO exit with error
+    }
 
-    osr = OSTREE_REPO (g_steal_pointer (&ret_repo));
+    // (TEST) get a list of refs
+        GHashTable *refs_hash = NULL;
+        gboolean result = ostree_repo_list_refs_ext(repo, NULL, &refs_hash, OSTREE_REPO_LIST_REFS_EXT_NONE, NULL, &error);
+        if (!result) {
+            g_printerr("Error listing refs: %s\n", error->message);
+            g_error_free(error);
+            g_object_unref(repo);
+            // TODO exit with error
+        }
+        // Iterate through the refs and print them
+        GHashTableIter iter;
+        gpointer key, value;
+        g_hash_table_iter_init(&iter, refs_hash);
+        while (g_hash_table_iter_next(&iter, &key, &value)) {
+            const gchar *ref_name = (const gchar *)key;
+            g_print("\nref found: %s\n", ref_name);
+        }
+        // Cleanup: Free resources
+        g_hash_table_unref(refs_hash);
+    // (TEST)
+
+    osr = repo;
 }
 
 OSTreeRepo::~OSTreeRepo() {
-    g_free(osr);
+    g_object_unref(osr);
 }
 
-OstreeRepo* OSTreeRepo::_c() {
+// METHODS
+
+auto OSTreeRepo::_c() -> OstreeRepo* {
     return osr;
+}
+
+auto OSTreeRepo::getRepo() -> std::string* {
+    // TODO
+    return nullptr;
+}
+
+auto OSTreeRepo::getCommitList() -> std::vector<Commit>* {
+    // TODO
+    std::vector<Commit> ret;
+    return &ret;
+}
+
+auto OSTreeRepo::getCommitListSorted() -> std::vector<Commit>* {
+    // TODO
+    std::vector<Commit> ret;
+    return &ret;
+}
+
+auto OSTreeRepo::getBranches() -> std::vector<std::string>* {
+    // TODO
+    std::vector<std::string> ret;
+    return &ret;
+}
+
+auto OSTreeRepo::updateData() -> bool {
+    // TODO
+    return false;
+}
+
+auto OSTreeRepo::isCommitSigned(const Commit& commit) -> bool {
+    // TODO
+    return false;
+}
+
+auto OSTreeRepo::parseCommits(std::string branch) -> std::vector<Commit> {
+    // TODO
+    return std::vector<Commit>();
+}
+
+auto OSTreeRepo::parseCommitsAllBranches() -> std::vector<Commit> {
+    // TODO
+    return std::vector<Commit>();
+}
+
+auto OSTreeRepo::getBranchesAsString() -> std::string {
+    // TODO
+    return "";
+}
+
+auto OSTreeRepo::getLogStringOfBranch(const std::string& branch) -> std::string {
+    // TODO
+    return "";
+}
+
+void OSTreeRepo::setBranches(std::vector<std::string> branches) { // TODO replace -> update (don't modify from outside)
+    // TODO
 }

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -1,4 +1,3 @@
-/*
 #include "cpplibostree.h"
 
 // C++
@@ -16,14 +15,16 @@
 using namespace cpplibostree;
 
 OSTreeRepo::OSTreeRepo(std::string repo_path) {
-    int dfd;
-    if ((dfd = open(repo_path.c_str(), O_DIRECTORY | O_RDONLY)) == -1) {
-    	std::cout << "couldn't find repository '" + repo_path + "'\n";
-    }
-    osr = ostree_repo_open_at (dfd,
-             repo_path.c_str(),
-             nullptr,
-             nullptr);
+
+    g_autoptr (GError) error = NULL;
+    OstreeRepo *repo = NULL;
+
+    g_autoptr (GFile) repo_path_ptr = g_file_new_for_path (repo_path.c_str());
+    g_autoptr (OstreeRepo) ret_repo = ostree_repo_new (repo_path_ptr);
+    if (!ostree_repo_open (ret_repo, NULL, &error))
+        std::cout << "ostree error\n";
+
+    osr = OSTREE_REPO (g_steal_pointer (&ret_repo));
 }
 
 OSTreeRepo::~OSTreeRepo() {
@@ -33,4 +34,3 @@ OSTreeRepo::~OSTreeRepo() {
 OstreeRepo* OSTreeRepo::_c() {
     return osr;
 }
-*/

--- a/src/util/cpplibostree.h
+++ b/src/util/cpplibostree.h
@@ -1,5 +1,5 @@
 /*_____________________________________________________________
- | incomplete Wrapper for libostree for C++
+ | partial C++ wrapper for libostree
  | - C++ style lifetimes
  | - C++ style usage
  |
@@ -20,7 +20,7 @@
 #include <cerrno>
 #include <fcntl.h>
 // external
-#include "glib.h"
+#include <glib-2.0/glib.h>
 #include <ostree-1/ostree.h>
 
 

--- a/src/util/cpplibostree.h
+++ b/src/util/cpplibostree.h
@@ -50,9 +50,6 @@ namespace cpplibostree {
         // custom methods
         OstreeRepo* _c();
 
-        // libostree methods
-        GHashTable ostree_repo_list_refs(std::string refspec_prefix);
-
         // Getters
 
             std::string* getRepo();

--- a/src/util/cpplibostree.h
+++ b/src/util/cpplibostree.h
@@ -9,19 +9,33 @@
  | - cancellable is automatically generated & doesn't need to
  |   be passed
  | - errors are thrown, not passed as pointer
- |___________________________________________________________/
+ |___________________________________________________________*/
 
 // C++
 #include <string>
+#include <vector>
+#include <set>
 // C
 #include <cstdio>
 #include <cerrno>
 #include <fcntl.h>
 // external
-#include <ostree.h>
-#include <glib.h>
+#include "glib.h"
+#include <ostree-1/ostree.h>
+
 
 namespace cpplibostree {
+
+    /// TODO remove & replace by GVariant Commit of ostreelib
+    struct Commit {
+        std::string hash;
+        std::string parent;
+        std::string contentChecksum;
+        std::string date;
+        std::string subject;
+    	std::string branch;
+        std::set<std::string> signatures;// replace with signature
+    };
 
     class OSTreeRepo {
     public:
@@ -39,7 +53,28 @@ namespace cpplibostree {
         // libostree methods
         GHashTable ostree_repo_list_refs(std::string refspec_prefix);
 
-    }; // class OSTreeRepo
+        // Getters
+
+            std::string* getRepo();
+            std::vector<Commit>* getCommitList();
+            std::vector<Commit>* getCommitListSorted();
+            std::vector<std::string>* getBranches();
+
+        // Methods
+
+            /// update all data
+            bool updateData();
+            /// check if a certain commit is signed
+            bool isCommitSigned(const Commit& commit);
+            /// parse commits from a ostree log output
+            std::vector<Commit> parseCommits(std::string branch);
+            /// same as parseCommits(), but on all available branches
+            std::vector<Commit> parseCommitsAllBranches();
+            /// get ostree refs
+            std::string getBranchesAsString();
+            std::string getLogStringOfBranch(const std::string& branch);
+            void setBranches(std::vector<std::string> branches); // TODO replace -> update (don't modify from outside)
+
+    };
 
 } // namespace cpplibostree
-*/


### PR DESCRIPTION
2 things are done, to set up the implementation of the partial C++ wrapper for libostree in this PR:

1. Set up all CMakeLists to properly include `libostree` and `glib`
2. Set up the "skeleton" for the wrapper

`cpplibostree.cpp` should now be ready for all needed function implementations.