### PR TITLE
Content promotion & UI redesign

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG v4.0.0
+  GIT_TAG v5.0.0
 )
 
 FetchContent_GetProperties(ftxui)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ include(FetchContent)
 set(FETCHCONTENT_UPDATES_DISCONNECTED TRUE)
 FetchContent_Declare(ftxui
   GIT_REPOSITORY https://github.com/ArthurSonzogni/ftxui
-  GIT_TAG v5.0.0
+  GIT_TAG main
 )
 
 FetchContent_GetProperties(ftxui)

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -184,19 +184,21 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 	// blocks the chosen letters from any TUI-internal text input
 	Component main_container = CatchEvent(container | border, [&](const Event& event) {
 		// copy commit id
-    	if (event == Event::Character('c')) {
+    	if (event == Event::AltC) {
 			std::string hash = visible_commit_view_map.at(selected_commit);
 			clip::set_text(hash);
+			notification_text = " Copied Hash " + hash + " ";
     	  	return true;
     	}
 		// refresh repository
-		if (event == Event::Character('r')) {
+		if (event == Event::AltR) {
 			refresh_repository();
+			notification_text = " Refreshed Repository Data ";
 			return true;
 		}
 		// exit
-    	if (event == Event::Character('q') || event == Event::Escape) {
-    	  	screen.ExitLoopClosure()();
+    	if (event == Event::AltQ || event == Event::Escape) {
+			screen.ExitLoopClosure()();
     	  	return true;
     	}
     	return false;

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -107,7 +107,9 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 
 	auto screen = ScreenInteractive::Fullscreen();
 	
-	Manager manager(ostree_repo, visible_branches);
+	std::vector<std::string> allBranches = ostree_repo.getBranches();
+
+	Manager manager(ostree_repo, visible_branches, allBranches);
 	Component branch_boxes = manager.branch_boxes;
 	Component manager_renderer = Renderer(branch_boxes, [&] {
 
@@ -116,7 +118,7 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 			commit_info = text(" no commit info available ") | color(Color::RedLight) | bold | center;
 		} else if (rebaseMode) {
 			cpplibostree::Commit display_commit = ostree_repo.getCommitList().at(visible_commit_view_map.at(selected_commit));
-			commit_info = Manager::renderPromotionWindow(display_commit);
+			commit_info = Manager::renderPromotionWindow(display_commit, manager.promotionRefSelection);
 		} else {
 			cpplibostree::Commit display_commit = ostree_repo.getCommitList().at(visible_commit_view_map.at(selected_commit));
 			commit_info = Manager::renderInfo(display_commit);

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -126,7 +126,7 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 	// promotion
 	ContentPromotionManager promotionManager;
 	promotionManager.branch_selection = Radiobox(&allBranches, &promotionManager.branch_selected);
-	promotionManager.apply_button = Button("Apply", [&] {
+	promotionManager.apply_button = Button(" Apply ", [&] {
 		ostree_repo.promoteCommit(visible_commit_view_map.at(selected_commit),
 								  ostree_repo.getBranches().at(static_cast<size_t>(promotionManager.branch_selected)),
 								  promotionManager.metadata_entries, promotionManager.new_subject,

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -48,7 +48,7 @@ std::vector<std::string> OSTreeTUI::parseVisibleCommitMap(cpplibostree::OSTreeRe
 	return visible_commit_view_map;
 }
 
-int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& startupBranches) {
+int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& startupBranches, bool showTooltips) {
 	using namespace ftxui;
 
 	// - STATES ---------- ----------
@@ -124,7 +124,7 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 	});
 
 	// promotion
-	ContentPromotionManager promotionManager;
+	ContentPromotionManager promotionManager(showTooltips);
 	promotionManager.setBranchRadiobox(Radiobox(&allBranches, &promotionManager.branch_selected));
 	promotionManager.setApplyButton(Button(" Apply ", [&] {
 		ostree_repo.promoteCommit(visible_commit_view_map.at(selected_commit),
@@ -238,6 +238,7 @@ int OSTreeTUI::help(const std::string& caller, const std::string& errorMessage) 
 		// option, arguments, meaning
 		{"-h, --help", "", "Show help options. The REPOSITORY_PATH can be omitted"},
 		{"-r, --refs", "REF [REF...]", "Specify a list of visible refs at startup if not specified, show all refs"},
+		{"-n, --no-tooltips", "", "Hide Tooltips in promotion view."}
 	};
 
 	Elements options   = {text("Options:")};

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -129,7 +129,7 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 	promotionManager.apply_button = Button(" Apply ", [&] {
 		ostree_repo.promoteCommit(visible_commit_view_map.at(selected_commit),
 								  ostree_repo.getBranches().at(static_cast<size_t>(promotionManager.branch_selected)),
-								  promotionManager.metadata_entries, promotionManager.new_subject,
+								  {}, promotionManager.new_subject,
 								  promotionManager.options_state[0]);
 		refresh_repository();
 		notification_text = " Applied content promotion. ";

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -60,7 +60,9 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 	std::vector<std::string> visible_commit_view_map{};			// map from view-index to commit-hash
 	std::unordered_map<std::string, Color> branch_color_map{};	// map branch to color
 
-	// set all branch visibilities and define a branch color
+	bool rebaseMode{false};
+	
+	// set all branches as visible and define a branch color
 	for (const auto& branch : ostree_repo.getBranches()) {
 		// if startupBranches are defined, set all as non-visible
 		visible_branches[branch] = startupBranches.size() == 0 ? true : false;
@@ -112,9 +114,12 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 		Element commit_info;
 		if (visible_commit_view_map.size() <= 0) {
 			commit_info = text(" no commit info available ") | color(Color::RedLight) | bold | center;
+		} else if (rebaseMode) {
+			cpplibostree::Commit display_commit = ostree_repo.getCommitList().at(visible_commit_view_map.at(selected_commit));
+			commit_info = Manager::renderPromotionWindow(display_commit);
 		} else {
 			cpplibostree::Commit display_commit = ostree_repo.getCommitList().at(visible_commit_view_map.at(selected_commit));
-			commit_info = Manager::render(display_commit);
+			commit_info = Manager::renderInfo(display_commit);
 		}
 		
 	    return vbox({
@@ -158,8 +163,9 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
     	  	return true;
     	}
 		// enter rebase mode
-    	if (event == Event::Character('b')) {
+    	if (event == Event::Character('p')) {
     	  	std::cout << "rebase not implemented yet" << std::endl;
+			rebaseMode = !rebaseMode;
     	  	return true;
     	}
 		// copy commit id

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -174,7 +174,11 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
   	container = ResizableSplitLeft(log_renderer, container, &log_size);
   	container = ResizableSplitBottom(footer_renderer, container, &footer_size);
 	
+	log_renderer->TakeFocus();
+
 	// add shortcuts
+	// TODO change to shift+ctrl+, or change any other way, as it currently
+	// blocks the chosen letters from any TUI-internal text input
 	Component main_container = CatchEvent(container | border, [&](const Event& event) {
 		// copy commit id
     	if (event == Event::Character('c')) {
@@ -209,7 +213,7 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 				footer.resetContent();
 				screen.Post(Event::Custom);
 			}
-			std::this_thread::sleep_for(0.5s);
+			std::this_thread::sleep_for(0.2s);
 		}
 	});
 
@@ -227,7 +231,7 @@ int OSTreeTUI::help(const std::string& caller, const std::string& errorMessage) 
 	// define command line options
 	std::vector<std::vector<std::string>> command_options = {
 		// option, arguments, meaning
-		{"-h, --help", "", "Show help options the REPOSITORY_PATH can be ommited"},
+		{"-h, --help", "", "Show help options. The REPOSITORY_PATH can be omitted"},
 		{"-r, --refs", "REF [REF...]", "Specify a list of visible refs at startup if not specified, show all refs"},
 	};
 

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -125,15 +125,15 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 
 	// promotion
 	ContentPromotionManager promotionManager;
-	promotionManager.branch_selection = Radiobox(&allBranches, &promotionManager.branch_selected);
-	promotionManager.apply_button = Button(" Apply ", [&] {
+	promotionManager.setBranchRadiobox(Radiobox(&allBranches, &promotionManager.branch_selected));
+	promotionManager.setApplyButton(Button(" Apply ", [&] {
 		ostree_repo.promoteCommit(visible_commit_view_map.at(selected_commit),
 								  ostree_repo.getBranches().at(static_cast<size_t>(promotionManager.branch_selected)),
 								  {}, promotionManager.new_subject,
 								  promotionManager.options_state[0]);
 		refresh_repository();
 		notification_text = " Applied content promotion. ";
-	}, ButtonOption::Simple());
+	}, ButtonOption::Simple()));
 	Component promotion_view = Renderer(promotionManager.composePromotionComponent(), [&] {
 		if (visible_commit_view_map.size() <= 0) {
 			return text(" please select a commit to continue commit-promotion... ") | color(Color::RedLight) | bold | center;

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -127,7 +127,10 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 	ContentPromotionManager promotionManager;
 	promotionManager.branch_selection = Radiobox(&allBranches, &promotionManager.branch_selected);
 	promotionManager.apply_button = Button("Apply", [&] {
-		// TODO call promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject = "", bool keepMetadata = false);  
+		ostree_repo.promoteCommit(visible_commit_view_map.at(selected_commit),
+								  ostree_repo.getBranches().at(static_cast<size_t>(promotionManager.branch_selected)),
+								  promotionManager.metadata_entries, promotionManager.new_subject,
+								  promotionManager.options_state[0]);
 		refresh_repository();
 		notification_text = " Applied content promotion. ";
 	}, ButtonOption::Simple());

--- a/src/core/OSTreeTUI.cpp
+++ b/src/core/OSTreeTUI.cpp
@@ -138,7 +138,7 @@ int OSTreeTUI::main(const std::string& repo, const std::vector<std::string>& sta
 		if (visible_commit_view_map.size() <= 0) {
 			return text(" please select a commit to continue commit-promotion... ") | color(Color::RedLight) | bold | center;
 		}
-		return promotionManager.renderPromotionView(ostree_repo,
+		return promotionManager.renderPromotionView(ostree_repo, screen.dimy(),
 			ostree_repo.getCommitList().at(visible_commit_view_map.at(selected_commit)));
     });
 

--- a/src/core/OSTreeTUI.hpp
+++ b/src/core/OSTreeTUI.hpp
@@ -15,7 +15,7 @@ namespace OSTreeTUI {
      * 
      * @param repo ostree repository path
      */
-    int main(const std::string& repo, const std::vector<std::string>& startupBranches = {});
+    int main(const std::string& repo, const std::vector<std::string>& startupBranches = {}, bool showTooltips = true);
 
     /**
      * @brief Print help page

--- a/src/core/commit.cpp
+++ b/src/core/commit.cpp
@@ -11,6 +11,16 @@
 
 namespace CommitRender {
 
+void addLine(const RenderTree& treeLineType, const RenderLine& lineType,
+			 ftxui::Elements& tree_elements, ftxui::Elements& comm_elements,
+			 const cpplibostree::Commit& commit,
+			 const bool& highlight,
+			 const std::unordered_map<std::string, bool>& used_branches,
+			 const std::unordered_map<std::string, ftxui::Color>& branch_color_map) {
+	tree_elements.push_back(addTreeLine(treeLineType, commit, used_branches, branch_color_map));
+	comm_elements.push_back(addCommLine(lineType, commit, highlight, branch_color_map));
+}
+
 ftxui::Element commitRender(cpplibostree::OSTreeRepo& repo,
                             const std::vector<std::string>& visible_commit_map,
                             const std::unordered_map<std::string, bool>& visible_branches,
@@ -61,18 +71,6 @@ ftxui::Element commitRender(cpplibostree::OSTreeRepo& repo,
 		vbox(std::move(comm_elements))
 	});
 }
-
-
-void addLine(const RenderTree& treeLineType, const RenderLine& lineType,
-			 ftxui::Elements& tree_elements, ftxui::Elements& comm_elements,
-			 const cpplibostree::Commit& commit,
-			 const bool& highlight,
-			 const std::unordered_map<std::string, bool>& used_branches,
-			 const std::unordered_map<std::string, ftxui::Color>& branch_color_map) {
-	tree_elements.push_back(addTreeLine(treeLineType, commit, used_branches, branch_color_map));
-	comm_elements.push_back(addCommLine(lineType, commit, highlight, branch_color_map));
-}
-
 
 ftxui::Element addTreeLine(const RenderTree& treeLineType,
 				 const cpplibostree::Commit& commit,

--- a/src/core/footer.cpp
+++ b/src/core/footer.cpp
@@ -1,10 +1,4 @@
-#include "ftxui/component/captured_mouse.hpp"  // for ftxui
-#include "ftxui/component/component.hpp"  // for Renderer, ResizableSplitBottom, ResizableSplitLeft, ResizableSplitRight, ResizableSplitTop
-#include "ftxui/component/component_base.hpp"      // for ComponentBase
-#include "ftxui/component/screen_interactive.hpp"  // for ScreenInteractive
 #include "ftxui/dom/elements.hpp"  // for Element, operator|, text, center, border
-#include "ftxui/screen/screen.hpp"
-#include "ftxui/screen/string.hpp"
 
 #include "footer.hpp"
 

--- a/src/core/footer.cpp
+++ b/src/core/footer.cpp
@@ -15,7 +15,7 @@ ftxui::Component footer::footerRender() {
 		return hbox({
 			text(" OSTree TUI ") | bold,
 			separator(),
-			text("  || (Q)uit || (R)efresh || (C)opy commit hash || (P)romote commit || "),
+			text("  || (Q)uit || (R)efresh || (C)opy commit hash || "),
 		});
 	});
 }

--- a/src/core/footer.cpp
+++ b/src/core/footer.cpp
@@ -12,7 +12,7 @@ ftxui::Element Footer::footerRender() {
 	using namespace ftxui;
 	
 	return hbox({
-		text(" OSTree TUI ") | bold,
+		text("OSTree TUI") | bold | hyperlink("https://github.com/AP-Sensing/ostree-tui"),
 		separator(),
 		text(content) | (content == DEFAULT_CONTENT ? color(Color::White) : color(Color::YellowLight)),
 	});

--- a/src/core/footer.cpp
+++ b/src/core/footer.cpp
@@ -8,14 +8,16 @@
 
 #include "footer.hpp"
 
-ftxui::Component footer::footerRender() {
+ftxui::Element Footer::footerRender() {
 	using namespace ftxui;
 	
-	return ftxui::Renderer([] {
-		return hbox({
-			text(" OSTree TUI ") | bold,
-			separator(),
-			text("  || (Q)uit || (R)efresh || (C)opy commit hash || "),
-		});
+	return hbox({
+		text(" OSTree TUI ") | bold,
+		separator(),
+		text(content) | (content == DEFAULT_CONTENT ? color(Color::White) : color(Color::YellowLight)),
 	});
+}
+
+void Footer::resetContent() {
+	content = DEFAULT_CONTENT;
 }

--- a/src/core/footer.cpp
+++ b/src/core/footer.cpp
@@ -15,7 +15,7 @@ ftxui::Component footer::footerRender() {
 		return hbox({
 			text(" OSTree TUI ") | bold,
 			separator(),
-			text("  || (Q)uit || (R)efresh || (C)opy commit hash ||  "),
+			text("  || (Q)uit || (R)efresh || (C)opy commit hash || (P)romote commit || "),
 		});
 	});
 }

--- a/src/core/footer.hpp
+++ b/src/core/footer.hpp
@@ -9,7 +9,7 @@
 
 class Footer {
 public:
-    const std::string DEFAULT_CONTENT   {"  || (Q)uit || (R)efresh || (C)opy commit hash || "};
+    const std::string DEFAULT_CONTENT   {"  || Alt+Q / Esc : Quit || Alt+R : Refresh || Alt+C : Copy commit hash || "};
     std::string content                 {DEFAULT_CONTENT};
 
 public:

--- a/src/core/footer.hpp
+++ b/src/core/footer.hpp
@@ -7,9 +7,17 @@
 #include "ftxui/component/component.hpp"        // for ftxui
 #include "ftxui/component/component_base.hpp"   // for Component
 
-namespace footer{
+class Footer {
+public:
+    const std::string DEFAULT_CONTENT   {"  || (Q)uit || (R)efresh || (C)opy commit hash || "};
+    std::string content                 {DEFAULT_CONTENT};
+
+public:
+    Footer() = default;
+    
+    /// reset footer text to default string
+    void resetContent();
 
     /// create a Renderer for the footer section
-    ftxui::Component footerRender();
-
-} // namespace footer
+    ftxui::Element footerRender();
+};

--- a/src/core/footer.hpp
+++ b/src/core/footer.hpp
@@ -4,8 +4,6 @@
  |   keyboard shortcuts info.
  |___________________________________________________________*/
 
-#include "ftxui/component/component.hpp"        // for ftxui
-#include "ftxui/component/component_base.hpp"   // for Component
 
 class Footer {
 public:

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -111,25 +111,6 @@ ContentPromotionManager::ContentPromotionManager() {
   	});
 }
 
-ftxui::Component ContentPromotionManager::composePromotionComponent() {
-	using namespace ftxui;
-
-	return Container::Vertical({
-		branch_selection,
-		Container::Horizontal({
-  	    	flags,
-  	    	Container::Vertical({
-  	    	    subject_component,
-  	    	    Container::Horizontal({
-  	    	        metadata_add,
-  	    	        metadata_input,
-  	    	    }),
-  	    	}),
-  		}),
-		apply_button
-	});
-}
-
 ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash) {
     using namespace ftxui;
 	
@@ -164,13 +145,34 @@ ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OS
     return line;
 }
 
+ftxui::Component ContentPromotionManager::composePromotionComponent() {
+	using namespace ftxui;
+
+	return Container::Vertical({
+		branch_selection,
+		Container::Horizontal({
+  	    	flags,
+  	    	Container::Vertical({
+  	    	    Container::Horizontal({
+  	    	        metadata_add,
+  	    	        metadata_input,
+  	    	    }),
+				Container::Horizontal({
+  	    	        subject_component,
+  	    	        apply_button,
+  	    	    }),
+  	    	}),
+  		}),
+	});
+}
+
 ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit) {
 	using namespace ftxui;
 
 	auto commit_hash	= window(text("Commit"), text(display_commit.hash) | flex) | size(HEIGHT, LESS_THAN, 3);
-	auto branch_win 	= window(text("New Branch"), branch_selection->Render() | vscroll_indicator | frame);
+	auto branch_win 	= window(text("New Branch"), branch_selection->Render() | vscroll_indicator | frame | size(HEIGHT, LESS_THAN, 2));
     auto flags_win 		= window(text("Flags"), flags->Render() | vscroll_indicator | frame);
-    auto subject_win 	= window(text("Subject"), subject_component->Render());
+    auto subject_win 	= window(text("Subject"), subject_component->Render()) | flex;
     auto metadata_win 	= 
 		window(text("Metadata Strings"),
 			hbox({
@@ -179,10 +181,10 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
                     metadata_add->Render(),
                 }) | size(WIDTH, EQUAL, 20) | size(HEIGHT, EQUAL, 1),
                 separator(),
-                metadata_input->Render() | vscroll_indicator | frame | size(HEIGHT, EQUAL, 3) | flex,
+                metadata_input->Render() | vscroll_indicator | frame | size(HEIGHT, EQUAL, 2) | flex,
             })
 		);
-	auto aButton_win 	= apply_button->Render() | color(Color::Green);
+	auto aButton_win 	= apply_button->Render() | color(Color::Green) | size(WIDTH, GREATER_THAN, 9) | flex;
 	
     return vbox({
 			commit_hash,
@@ -190,12 +192,14 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
             hbox({
                 flags_win,
                 vbox({
-                    subject_win | size(WIDTH, EQUAL, 20),
                     metadata_win | size(WIDTH, EQUAL, 60),
+                    hbox({
+						subject_win | size(WIDTH, EQUAL, 20),
+						aButton_win,
+					}),
                 }),
                 filler(),
             }) | size(HEIGHT, LESS_THAN, 8),
             hflow(renderPromotionCommand(ostree_repo, display_commit.hash)) | flex_grow,
-			aButton_win,
     }) | flex_grow;
 }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -173,6 +173,18 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
     auto subject_win 	= window(text("Subject"), subject_component->Render()) | flex;
 	auto aButton_win 	= apply_button->Render() | color(Color::Green) | size(WIDTH, GREATER_THAN, 9) | flex;
 	
+	auto toolTipContent = [&](size_t tip) {
+		return vbox({
+			separatorCharacter("⎯"),
+			text(" 🛈 " + tool_tip_strings.at(tip)),
+		});
+	};
+	auto tool_tips_win	= branch_selection->Focused()	? toolTipContent(0) :
+						  flags->Focused()				? toolTipContent(1) :
+						  subject_component->Focused()	? toolTipContent(2) :
+						  apply_button->Focused()		? toolTipContent(3) :
+						  filler();
+
     return vbox({
 			commit_hash,
 			branch_win,
@@ -185,5 +197,6 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
                 filler(),
             }) | size(HEIGHT, LESS_THAN, 8),
             hflow(renderPromotionCommand(ostree_repo, display_commit.hash)) | flex_grow,
+			tool_tips_win,
     }) | flex_grow;
 }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -20,15 +20,10 @@ Manager::Manager(const ftxui::Component& info_view, const ftxui::Component& filt
 			promotion_view
     	},
     	&tab_index);
-	
-	top_text_box = Renderer([&] { return text("Commit... ") | bold; });
 
 	manager_renderer = Container::Vertical({
-      	Container::Horizontal({
-			top_text_box,
-          	tab_selection
-      	}),
-      	tab_content,
+        tab_selection,
+      	tab_content
   	});
 }
 

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -2,7 +2,10 @@
 
 #include <cstdio>
 #include <string>
+#include <assert.h>
 
+#include "ftxui/component/component.hpp"  // for Renderer, ResizableSplitBottom, ResizableSplitLeft, ResizableSplitRight, ResizableSplitTop
+#include "ftxui/component/event.hpp"      // for Event
 #include "ftxui/dom/elements.hpp"  // for Element, operator|, text, center, border
 
 #include "../util/cpplibostree.hpp"
@@ -98,8 +101,27 @@ ContentPromotionManager::ContentPromotionManager() {
   	});
 }
 
+void ContentPromotionManager::setBranchRadiobox(ftxui::Component radiobox) {
+    using namespace ftxui;
+
+    branch_selection = CatchEvent(radiobox, [&](const Event& event) {
+    	// copy commit id
+    	if (event == Event::Return) {
+    		flags->TakeFocus();
+    	}
+    	return false;
+    });
+}
+
+void ContentPromotionManager::setApplyButton(ftxui::Component button) {
+	apply_button = button; 
+}
+
 ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash) {
     using namespace ftxui;
+
+	assert(branch_selection);
+	assert(apply_button);
 	
 	Elements line;
 	line.push_back(text("ostree commit") | bold);
@@ -141,6 +163,9 @@ ftxui::Component ContentPromotionManager::composePromotionComponent() {
 
 ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit) {
 	using namespace ftxui;
+
+	assert(branch_selection);
+	assert(apply_button);
 
 	auto commit_hash	= window(text("Commit"), text(display_commit.hash) | flex) | size(HEIGHT, LESS_THAN, 3);
 	auto branch_win 	= window(text("New Branch"), branch_selection->Render() | vscroll_indicator | frame | size(HEIGHT, LESS_THAN, 2));

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -90,7 +90,7 @@ ftxui::Element CommitInfoManager::renderInfoView(const cpplibostree::Commit& dis
 
 // ContentPromotionManager
 
-ContentPromotionManager::ContentPromotionManager() {
+ContentPromotionManager::ContentPromotionManager(bool show_tooltips): show_tooltips(show_tooltips) {
 	using namespace ftxui;
 
 	subject_component = Input(&new_subject, "subject");
@@ -191,7 +191,7 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
 			text(" 🛈 " + tool_tip_strings.at(tip)),
 		});
 	};
-	auto tool_tips_win	= tooltips_win_height < 2 ? filler() : // only show if screen is reasonable size
+	auto tool_tips_win	= !show_tooltips || tooltips_win_height < 2 ? filler() : // only show if screen is reasonable size
 						  branch_selection->Focused()	? toolTipContent(0) :
 						  flags->Focused()				? toolTipContent(1) :
 						  subject_component->Focused()	? toolTipContent(2) :

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -8,15 +8,13 @@
 #include "../util/cpplibostree.hpp"
 
 
-Manager::Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches, std::vector<std::string>& branches) {
+Manager::Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches) {
     using namespace ftxui;
 
 	// branch visibility
 	for (const auto& branch : repo.getBranches()) {
 		branch_boxes->Add(Checkbox(branch, &(visible_branches.at(branch))));
 	}
-
-	promotionRefSelection = Radiobox(&branches, &selectedPromotionRef);
 }
 
 ftxui::Element Manager::branchBoxRender(){
@@ -42,9 +40,9 @@ ftxui::Element Manager::renderInfo(const cpplibostree::Commit& display_commit) {
 		);
 	}
 	return vbox({
-			text("hash:       " + display_commit.hash),
+			window(text("subject"), paragraph(display_commit.subject)),
 			filler(),
-			paragraph("subject:    " + display_commit.subject),
+			text("hash:       " + display_commit.hash),
 			filler(),
 			text("date:       " + std::format("{:%Y-%m-%d %T %Ez}",
 								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
@@ -65,4 +63,121 @@ ftxui::Element Manager::renderPromotionWindow(const cpplibostree::Commit& displa
 	return  window(text("Commit"), vbox({
 			text("hash:       " + display_commit.hash),
 		}));
+}
+
+
+// ContentPromotionManager
+
+ContentPromotionManager::ContentPromotionManager() {
+	using namespace ftxui;
+
+	metadata_option.on_enter = [&] {
+  	  	metadata_entries.push_back(metadata_add_content);
+  	  	metadata_add_content = "";
+  	};
+
+	metadata_input = Menu(&metadata_entries, &input_selected);
+	metadata_add = Input(&metadata_add_content, "metadata string", metadata_option);
+
+	subject_component = Input(&new_subject, "subject");
+
+	flags = Container::Vertical({
+  	    Checkbox(&options_label[0], &options_state[0]),
+  	});
+}
+
+ftxui::Component ContentPromotionManager::composePromotionComponent(ftxui::Component& branch_selection, ftxui::Component& apply_button) {
+	using namespace ftxui;
+
+	return Container::Vertical({
+		branch_selection,
+		Container::Horizontal({
+  	    	flags,
+  	    	Container::Vertical({
+  	    	    subject_component,
+  	    	    Container::Horizontal({
+  	    	        metadata_add,
+  	    	        metadata_input,
+  	    	    }),
+  	    	}),
+  		}),
+		apply_button
+	});
+}
+
+ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash) {
+    using namespace ftxui;
+	
+	Elements line;
+	line.push_back(text("ostree commit") | bold);
+    line.push_back(text(" --repo=" + ostree_repo.getRepoPath()) | bold);
+	line.push_back(text(" -b " + ostree_repo.getBranches().at(branch_selected)) | bold);
+    // flags
+    for (int i = 0; i < 8; ++i) {
+      	if (options_state[i]) {
+        	line.push_back(text(" "));
+        	line.push_back(text(options_label[i]) | dim);
+     	}
+    }
+    // optional subject
+    if (!new_subject.empty()) {
+    	line.push_back(text(" -s ") | bold);
+    	line.push_back(text(new_subject) | color(Color::BlueLight) | bold);
+    }
+    // metadata additions
+	if (!metadata_entries.empty()) {
+		line.push_back(text(" --add-metadata-string=\"") | bold);
+    	for (auto& it : metadata_entries) {
+    		line.push_back(text(" " + it) | color(Color::RedLight));
+    	}
+		line.push_back(text("\"") | bold);
+	}
+	// commit
+	line.push_back(text(" --tree=ref=" + selected_commit_hash) | bold);
+
+    return line;
+}
+
+ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit, ftxui::Component& branch_selection, ftxui::Component& apply_button) {
+	using namespace ftxui;
+
+	auto commit_hash =
+		window(text("Commit"), text(display_commit.hash) | flex) | size(HEIGHT, LESS_THAN, 3);
+	auto branch_win =
+		window(text("New Branch"), branch_selection->Render() | vscroll_indicator | frame);
+    auto flags_win =
+        window(text("Flags"), flags->Render() | vscroll_indicator | frame);
+    auto subject_win =
+		window(text("Subject"), subject_component->Render());
+    auto metadata_win =
+        window(text("Metadata Strings"), hbox({
+                                  vbox({
+                                      hbox({
+                                          text("Add: "),
+                                          metadata_add->Render(),
+                                      }) | size(WIDTH, EQUAL, 20) |
+                                          size(HEIGHT, EQUAL, 1),
+                                      filler(),
+                                  }),
+                                  separator(),
+                                  metadata_input->Render() | vscroll_indicator | frame |
+                                      size(HEIGHT, EQUAL, 3) | flex,
+                              }));
+	auto aButton_win =
+		apply_button->Render() | color(Color::Green);
+	
+    return vbox({
+			commit_hash,
+			branch_win,
+            hbox({
+                flags_win,
+                vbox({
+                    subject_win | size(WIDTH, EQUAL, 20),
+                    metadata_win | size(WIDTH, EQUAL, 60),
+                }),
+                filler(),
+            }) | size(HEIGHT, LESS_THAN, 8),
+            hflow(renderPromotionCommand(ostree_repo, display_commit.hash)) | flex_grow,
+			aButton_win,
+    }) | flex_grow;
 }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -68,18 +68,24 @@ ftxui::Element CommitInfoManager::renderInfoView(const cpplibostree::Commit& dis
 		);
 	}
 	return vbox({
-			window(text("subject"), paragraph(display_commit.subject)),
+			window(text("Subject:"),
+				paragraph(display_commit.subject) | color(Color::White)
+			) | color(Color::Green),
 			filler(),
-			text("hash:       " + display_commit.hash),
+			text(" Hash:        ") | color(Color::Green), 
+			text(display_commit.hash),
 			filler(),
-			text("date:       " + std::format("{:%Y-%m-%d %T %Ez}",
+			text(" Date:        ") | color(Color::Green),
+			text(std::format("{:%Y-%m-%d %T %Ez}",
 								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
 			filler(),
-			text("parent:     " + display_commit.parent),
+			text(" Parent:      ") | color(Color::Green),
+			text(display_commit.parent),
 			filler(),
-			text("checksum:   " + display_commit.contentChecksum),
+			text(" C.-Checksum: ") | color(Color::Green),
+			text(display_commit.contentChecksum),
 			filler(),
-			display_commit.signatures.size() > 0 ? text("signatures: ") : text(""),
+			display_commit.signatures.size() > 0 ? text("signatures: ") | color(Color::Green) : text(""),
 			vbox(signatures),
 			filler()
 		});

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -24,7 +24,7 @@ ftxui::Element Manager::branchBoxRender(){
 	
 	// branch filter
 	Elements bfb_elements = {
-			text(L"filter branches") | bold,
+			text(L"branches:") | bold,
 			filler(),
 			branch_boxes->Render() | vscroll_indicator | frame | size(HEIGHT, LESS_THAN, 10),
 		};
@@ -42,11 +42,9 @@ ftxui::Element Manager::renderInfo(const cpplibostree::Commit& display_commit) {
 		);
 	}
 	return vbox({
-			text("commit info") | bold,
-			filler(),
 			text("hash:       " + display_commit.hash),
 			filler(),
-			text("subject:    " + display_commit.subject),
+			paragraph("subject:    " + display_commit.subject),
 			filler(),
 			text("date:       " + std::format("{:%Y-%m-%d %T %Ez}",
 								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
@@ -64,21 +62,7 @@ ftxui::Element Manager::renderInfo(const cpplibostree::Commit& display_commit) {
 ftxui::Element Manager::renderPromotionWindow(const cpplibostree::Commit& display_commit, ftxui::Component& rb) {
 	using namespace ftxui;
 
-	return vbox({
-			text("commit info") | bold,
-			filler(),
+	return  window(text("Commit"), vbox({
 			text("hash:       " + display_commit.hash),
-			filler(),
-			text("subject:    " + display_commit.subject),
-			filler(),
-			text("date:       " + std::format("{:%Y-%m-%d %T %Ez}",
-								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
-			filler(),
-			text(""),
-			text("  promote commit...") | bold | color(Color::Green),
-			filler(),
-			text("TODO insert ref selection"),
-			filler(),
-			rb->Render()
-		});
+		}));
 }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -136,9 +136,9 @@ ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OS
 	Elements line;
 	line.push_back(text("ostree commit") | bold);
     line.push_back(text(" --repo=" + ostree_repo.getRepoPath()) | bold);
-	line.push_back(text(" -b " + ostree_repo.getBranches().at(branch_selected)) | bold);
+	line.push_back(text(" -b " + ostree_repo.getBranches().at(static_cast<size_t>(branch_selected))) | bold);
     // flags
-    for (int i = 0; i < 8; ++i) {
+    for (size_t i = 0; i < 8; ++i) {
       	if (options_state[i]) {
         	line.push_back(text(" "));
         	line.push_back(text(options_label[i]) | dim);
@@ -146,16 +146,17 @@ ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OS
     }
     // optional subject
     if (!new_subject.empty()) {
-    	line.push_back(text(" -s ") | bold);
+    	line.push_back(text(" -s \"") | bold);
     	line.push_back(text(new_subject) | color(Color::BlueLight) | bold);
+		line.push_back(text("\"") | bold);
     }
     // metadata additions
 	if (!metadata_entries.empty()) {
-		line.push_back(text(" --add-metadata-string=\"") | bold);
     	for (auto& it : metadata_entries) {
-    		line.push_back(text(" " + it) | color(Color::RedLight));
+			line.push_back(text(" --add-metadata-string=\"") | bold);
+    		line.push_back(text(it) | color(Color::RedLight));
+			line.push_back(text("\"") | bold);
     	}
-		line.push_back(text("\"") | bold);
 	}
 	// commit
 	line.push_back(text(" --tree=ref=" + selected_commit_hash) | bold);

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -29,7 +29,7 @@ ftxui::Element Manager::branchBoxRender(){
 	return vbox(bfb_elements);
 }
 
-ftxui::Element Manager::render(const cpplibostree::Commit& display_commit) {
+ftxui::Element Manager::renderInfo(const cpplibostree::Commit& display_commit) {
 	using namespace ftxui;
 	
 	// selected commit info
@@ -56,5 +56,26 @@ ftxui::Element Manager::render(const cpplibostree::Commit& display_commit) {
 			display_commit.signatures.size() > 0 ? text("signatures: ") : text(""),
 			vbox(signatures),
 			filler(),
+		});
+}
+
+ftxui::Element Manager::renderPromotionWindow(const cpplibostree::Commit& display_commit) {
+	using namespace ftxui;
+
+	return vbox({
+			text("commit info") | bold,
+			filler(),
+			text("hash:       " + display_commit.hash),
+			filler(),
+			text("subject:    " + display_commit.subject),
+			filler(),
+			text("date:       " + std::format("{:%Y-%m-%d %T %Ez}",
+								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
+			separator(),
+			text(" promote to...") | bold,
+			filler(),
+			text("TODO insert ref selection"),
+			filler(),
+			text(" promote to...")
 		});
 }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -96,14 +96,6 @@ ftxui::Element CommitInfoManager::renderInfoView(const cpplibostree::Commit& dis
 ContentPromotionManager::ContentPromotionManager() {
 	using namespace ftxui;
 
-	metadata_option.on_enter = [&] {
-  	  	metadata_entries.push_back(metadata_add_content);
-  	  	metadata_add_content = "";
-  	};
-
-	metadata_input = Menu(&metadata_entries, &input_selected);
-	metadata_add = Input(&metadata_add_content, "metadata string", metadata_option);
-
 	subject_component = Input(&new_subject, "subject");
 
 	flags = Container::Vertical({
@@ -131,14 +123,6 @@ ftxui::Elements ContentPromotionManager::renderPromotionCommand(cpplibostree::OS
     	line.push_back(text(new_subject) | color(Color::BlueLight) | bold);
 		line.push_back(text("\"") | bold);
     }
-    // metadata additions
-	if (!metadata_entries.empty()) {
-    	for (auto& it : metadata_entries) {
-			line.push_back(text(" --add-metadata-string=\"") | bold);
-    		line.push_back(text(it) | color(Color::RedLight));
-			line.push_back(text("\"") | bold);
-    	}
-	}
 	// commit
 	line.push_back(text(" --tree=ref=" + selected_commit_hash) | bold);
 
@@ -153,14 +137,8 @@ ftxui::Component ContentPromotionManager::composePromotionComponent() {
 		Container::Horizontal({
   	    	flags,
   	    	Container::Vertical({
-  	    	    Container::Horizontal({
-  	    	        metadata_add,
-  	    	        metadata_input,
-  	    	    }),
-				Container::Horizontal({
-  	    	        subject_component,
-  	    	        apply_button,
-  	    	    }),
+				subject_component,
+  	    	    apply_button,
   	    	}),
   		}),
 	});
@@ -173,17 +151,6 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
 	auto branch_win 	= window(text("New Branch"), branch_selection->Render() | vscroll_indicator | frame | size(HEIGHT, LESS_THAN, 2));
     auto flags_win 		= window(text("Flags"), flags->Render() | vscroll_indicator | frame);
     auto subject_win 	= window(text("Subject"), subject_component->Render()) | flex;
-    auto metadata_win 	= 
-		window(text("Metadata Strings"),
-			hbox({
-                hbox({
-                    text("Add: "),
-                    metadata_add->Render(),
-                }) | size(WIDTH, EQUAL, 20) | size(HEIGHT, EQUAL, 1),
-                separator(),
-                metadata_input->Render() | vscroll_indicator | frame | size(HEIGHT, EQUAL, 2) | flex,
-            })
-		);
 	auto aButton_win 	= apply_button->Render() | color(Color::Green) | size(WIDTH, GREATER_THAN, 9) | flex;
 	
     return vbox({
@@ -192,11 +159,8 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
             hbox({
                 flags_win,
                 vbox({
-                    metadata_win | size(WIDTH, EQUAL, 60),
-                    hbox({
-						subject_win | size(WIDTH, EQUAL, 20),
-						aButton_win,
-					}),
+					subject_win | size(WIDTH, EQUAL, 60),
+					aButton_win,
                 }),
                 filler(),
             }) | size(HEIGHT, LESS_THAN, 8),

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -160,17 +160,19 @@ ftxui::Component ContentPromotionManager::composePromotionComponent() {
 	});
 }
 
-ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, int screenHeight, cpplibostree::Commit& display_commit) {
+ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, int screenHeight, const cpplibostree::Commit& display_commit) {
 	using namespace ftxui;
 
 	assert(branch_selection);
 	assert(apply_button);
 
 	// compute screen element sizes
-	int commit_win_height {3};
-	int apsect_win_height {8};
+	int screen_overhead		{8}; // borders, footer, etc.
+	int commit_win_height 	{3};
+	int apsect_win_height 	{8};
 	int tooltips_win_height {2};
-	int branch_select_win_height = screenHeight - 8 /*overhead screen*/ - commit_win_height - apsect_win_height - tooltips_win_height;
+	int branch_select_win_height = screenHeight - screen_overhead - commit_win_height - apsect_win_height - tooltips_win_height;
+	// tooltips only get shown, if the window is sufficiently large
 	if (branch_select_win_height < 4) {
 		tooltips_win_height = 0;
 		branch_select_win_height = 4;
@@ -182,7 +184,7 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
     auto flags_win 		= window(text("Flags"), flags->Render() | vscroll_indicator | frame);
     auto subject_win 	= window(text("Subject"), subject_component->Render()) | flex;
 	auto aButton_win 	= apply_button->Render() | color(Color::Green) | size(WIDTH, GREATER_THAN, 9) | flex;
-	
+
 	auto toolTipContent = [&](size_t tip) {
 		return vbox({
 			separatorCharacter("⎯"),

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -8,13 +8,15 @@
 #include "../util/cpplibostree.hpp"
 
 
-Manager::Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches) {
+Manager::Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches, std::vector<std::string>& branches) {
     using namespace ftxui;
 
 	// branch visibility
 	for (const auto& branch : repo.getBranches()) {
 		branch_boxes->Add(Checkbox(branch, &(visible_branches.at(branch))));
 	}
+
+	promotionRefSelection = Radiobox(&branches, &selectedPromotionRef);
 }
 
 ftxui::Element Manager::branchBoxRender(){
@@ -55,11 +57,11 @@ ftxui::Element Manager::renderInfo(const cpplibostree::Commit& display_commit) {
 			filler(),
 			display_commit.signatures.size() > 0 ? text("signatures: ") : text(""),
 			vbox(signatures),
-			filler(),
+			filler()
 		});
 }
 
-ftxui::Element Manager::renderPromotionWindow(const cpplibostree::Commit& display_commit) {
+ftxui::Element Manager::renderPromotionWindow(const cpplibostree::Commit& display_commit, ftxui::Component& rb) {
 	using namespace ftxui;
 
 	return vbox({
@@ -71,11 +73,12 @@ ftxui::Element Manager::renderPromotionWindow(const cpplibostree::Commit& displa
 			filler(),
 			text("date:       " + std::format("{:%Y-%m-%d %T %Ez}",
 								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
-			separator(),
-			text(" promote to...") | bold,
+			filler(),
+			text(""),
+			text("  promote commit...") | bold | color(Color::Green),
 			filler(),
 			text("TODO insert ref selection"),
 			filler(),
-			text(" promote to...")
+			rb->Render()
 		});
 }

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -66,9 +66,8 @@ ftxui::Element CommitInfoManager::renderInfoView(const cpplibostree::Commit& dis
 		);
 	}
 	return vbox({
-			window(text("Subject:"),
-				paragraph(display_commit.subject) | color(Color::White)
-			) | color(Color::Green),
+			text(" Subject:") | color(Color::Green),
+			paragraph(display_commit.subject) | color(Color::White),
 			filler(),
 			text(" Hash: ") | color(Color::Green), 
 			text(display_commit.hash),
@@ -178,7 +177,7 @@ ftxui::Element ContentPromotionManager::renderPromotionView(cpplibostree::OSTree
 	}
 
 	// build elements
-	auto commit_hash	= window(text("Commit"), text(display_commit.hash) | flex);
+	auto commit_hash	= vbox({text(" Commit: ") | bold | color(Color::Green), text(" " + display_commit.hash)}) | flex;
 	auto branch_win 	= window(text("New Branch"), branch_selection->Render() | vscroll_indicator | frame);
     auto flags_win 		= window(text("Flags"), flags->Render() | vscroll_indicator | frame);
     auto subject_win 	= window(text("Subject"), subject_component->Render()) | flex;

--- a/src/core/manager.cpp
+++ b/src/core/manager.cpp
@@ -62,7 +62,7 @@ ftxui::Element CommitInfoManager::renderInfoView(const cpplibostree::Commit& dis
 	Elements signatures;
 	for (const auto& signature : display_commit.signatures) {
 		signatures.push_back(
-			text("    " + signature.pubkey_algorithm + " " + signature.fingerprint)
+			text("• " + signature.pubkey_algorithm + " " + signature.fingerprint)
 		);
 	}
 	return vbox({
@@ -70,20 +70,20 @@ ftxui::Element CommitInfoManager::renderInfoView(const cpplibostree::Commit& dis
 				paragraph(display_commit.subject) | color(Color::White)
 			) | color(Color::Green),
 			filler(),
-			text(" Hash:        ") | color(Color::Green), 
+			text(" Hash: ") | color(Color::Green), 
 			text(display_commit.hash),
 			filler(),
-			text(" Date:        ") | color(Color::Green),
+			text(" Date: ") | color(Color::Green),
 			text(std::format("{:%Y-%m-%d %T %Ez}",
 								std::chrono::time_point_cast<std::chrono::seconds>(display_commit.timestamp))),
 			filler(),
-			text(" Parent:      ") | color(Color::Green),
+			text(" Parent: ") | color(Color::Green),
 			text(display_commit.parent),
 			filler(),
-			text(" C.-Checksum: ") | color(Color::Green),
+			text(" Checksum: ") | color(Color::Green),
 			text(display_commit.contentChecksum),
 			filler(),
-			display_commit.signatures.size() > 0 ? text("signatures: ") | color(Color::Green) : text(""),
+			display_commit.signatures.size() > 0 ? text(" Signatures: ") | color(Color::Green) : text(""),
 			vbox(signatures),
 			filler()
 		});

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -125,5 +125,5 @@ public:
      * @warning branch_selection & apply_button have to be set first (checked through assert)
      * @return ftxui::Element
      */
-    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit);
+    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, int screenHeight, cpplibostree::Commit& display_commit);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -18,14 +18,61 @@
 class Manager {
 public:
     ftxui::Component branch_boxes = ftxui::Container::Vertical({});
-    ftxui::Component promotionRefSelection;
-    int selectedPromotionRef{0};
 
 //public:
-    Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches, std::vector<std::string>& branches);
+    Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches);
     
     ftxui::Element branchBoxRender();
 
     static ftxui::Element renderInfo(const cpplibostree::Commit& display_commit);
     static ftxui::Element renderPromotionWindow(const cpplibostree::Commit& display_commit, ftxui::Component& rb);
+};
+
+class CommitInfoManager {
+
+};
+
+class BranchBoxManager {
+
+};
+
+class ContentPromotionManager {
+public:
+    // branch selection
+    int branch_selected{0};
+
+    // flag selection
+    ftxui::Component flags;
+
+    std::array<std::string, 8> options_label = {
+  	    "--keep-metadata",
+  	};
+  	std::array<bool, 8> options_state = {
+  	    false,
+  	};
+
+    // metadata entries
+    ftxui::Component metadata_add;
+
+    std::vector<std::string> metadata_entries;
+  	int input_selected{0};
+
+    ftxui::Component metadata_input;
+    
+    ftxui::InputOption metadata_option = ftxui::InputOption();
+  	std::string metadata_add_content;
+
+    // subject
+    ftxui::Component subject_component;
+
+    std::string new_subject{""};
+
+public:
+    ContentPromotionManager();
+
+    ftxui::Component composePromotionComponent(ftxui::Component& branch_selection, ftxui::Component& apply_button);
+
+    ftxui::Elements renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash);
+
+    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit, ftxui::Component& branch_selection, ftxui::Component& apply_button);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -76,12 +76,15 @@ public:
 public:
     ContentPromotionManager();
 
-    /// Warning: branch_selection & apply_button have to be set first (TODO check in method)
+    void setBranchRadiobox(ftxui::Component radiobox);
+    void setApplyButton(ftxui::Component button);
+
+    /// Warning: branch_selection & apply_button have to be set first
     ftxui::Component composePromotionComponent();
 
     /// renders the promotion command resulting from the current user settings (ostree commit ...) 
     ftxui::Elements renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash);
 
-    /// Warning: branch_selection & apply_button have to be set first (TODO check in method)
+    /// Warning: branch_selection & apply_button have to be set first
     ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -14,31 +14,47 @@
 #include "../util/cpplibostree.hpp"
 #include "commit.hpp"
 
-/// Right postion of main window
+/// Interchangeable View
 class Manager {
 public:
-    ftxui::Component branch_boxes = ftxui::Container::Vertical({});
+    int tab_index{0};
 
-//public:
-    Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches);
-    
-    ftxui::Element branchBoxRender();
+    std::vector<std::string> tab_entries = {
+    	" Info ", " Filter ", " Promote "
+  	};
 
-    static ftxui::Element renderInfo(const cpplibostree::Commit& display_commit);
-    static ftxui::Element renderPromotionWindow(const cpplibostree::Commit& display_commit, ftxui::Component& rb);
+    ftxui::Component tab_selection;
+    ftxui::Component tab_content;
+
+    ftxui::Component top_text_box;
+
+    // because the combination of all interchangeable views is very simple,
+    // we can (in contrast to the other ones) render this one immediately
+    ftxui::Component manager_renderer;
+
+public:
+    Manager(const ftxui::Component& info_view, const ftxui::Component& filter_view, const ftxui::Component& promotion_view);
 };
 
 class CommitInfoManager {
-
+public:
+    static ftxui::Element renderInfoView(const cpplibostree::Commit& display_commit);
 };
 
 class BranchBoxManager {
+public:
+    ftxui::Component branch_boxes = ftxui::Container::Vertical({});
 
+public:
+    BranchBoxManager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches);
+    
+    ftxui::Element branchBoxRender();
 };
 
 class ContentPromotionManager {
 public:
     // branch selection
+    ftxui::Component branch_selection; // must be set from OSTreeTUI
     int branch_selected{0};
 
     // flag selection
@@ -67,12 +83,18 @@ public:
 
     std::string new_subject{""};
 
+    // apply button
+    ftxui::Component apply_button; // must be set from OSTreeTUI
+
 public:
     ContentPromotionManager();
 
-    ftxui::Component composePromotionComponent(ftxui::Component& branch_selection, ftxui::Component& apply_button);
+    /// Warning: branch_selection & apply_button have to be set first (TODO check in method)
+    ftxui::Component composePromotionComponent();
 
+    /// renders the promotion command resulting from the current user settings (ostree commit ...) 
     ftxui::Elements renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash);
 
-    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit, ftxui::Component& branch_selection, ftxui::Component& apply_button);
+    /// Warning: branch_selection & apply_button have to be set first (TODO check in method)
+    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -23,5 +23,7 @@ public:
     Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches);
     
     ftxui::Element branchBoxRender();
-    static ftxui::Element render(const cpplibostree::Commit& display_commit);
+
+    static ftxui::Element renderInfo(const cpplibostree::Commit& display_commit);
+    static ftxui::Element renderPromotionWindow(const cpplibostree::Commit& display_commit);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -67,17 +67,6 @@ public:
   	    false,
   	};
 
-    // metadata entries
-    ftxui::Component metadata_add;
-
-    std::vector<std::string> metadata_entries;
-  	int input_selected{0};
-
-    ftxui::Component metadata_input;
-    
-    ftxui::InputOption metadata_option = ftxui::InputOption();
-  	std::string metadata_add_content;
-
     // subject
     ftxui::Component subject_component;
 

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -12,7 +12,6 @@
 #include "ftxui/component/component.hpp"  // for Component
 
 #include "../util/cpplibostree.hpp"
-#include "commit.hpp"
 
 /// Interchangeable View
 class Manager {
@@ -69,7 +68,7 @@ public:
     // flag selection
     ftxui::Component flags;
 
-    std::array<std::string, 8> options_label = {
+    const std::array<std::string, 8> options_label = {
   	    "--keep-metadata",
   	};
   	std::array<bool, 8> options_state = {
@@ -86,7 +85,7 @@ public:
 
     // tool-tips
     ftxui::Component tool_tips_comp;
-    std::vector<std::string> tool_tip_strings = {
+    const std::vector<std::string> tool_tip_strings = {
         "Branch to promote the Commit to.",
         "Additional Flags to set.",
         "New subject for promoted Commit (optional).",
@@ -125,5 +124,5 @@ public:
      * @warning branch_selection & apply_button have to be set first (checked through assert)
      * @return ftxui::Element
      */
-    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, int screenHeight, cpplibostree::Commit& display_commit);
+    ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, int screenHeight, const cpplibostree::Commit& display_commit);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -84,6 +84,15 @@ public:
     // apply button
     ftxui::Component apply_button; // must be set from OSTreeTUI
 
+    // tool-tips
+    ftxui::Component tool_tips_comp;
+    std::vector<std::string> tool_tip_strings = {
+        "Branch to promote the Commit to.",
+        "Additional Flags to set.",
+        "New subject for promoted Commit (optional).",
+        "Apply the Commit Promotion (write to repository).",
+    };
+
 public:
     /**
      * @brief Constructor for the Promotion Manager.

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -18,12 +18,14 @@
 class Manager {
 public:
     ftxui::Component branch_boxes = ftxui::Container::Vertical({});
+    ftxui::Component promotionRefSelection;
+    int selectedPromotionRef{0};
 
 //public:
-    Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches);
+    Manager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches, std::vector<std::string>& branches);
     
     ftxui::Element branchBoxRender();
 
     static ftxui::Element renderInfo(const cpplibostree::Commit& display_commit);
-    static ftxui::Element renderPromotionWindow(const cpplibostree::Commit& display_commit);
+    static ftxui::Element renderPromotionWindow(const cpplibostree::Commit& display_commit, ftxui::Component& rb);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -36,6 +36,12 @@ public:
 
 class CommitInfoManager {
 public:
+    /**
+     * @brief Build the info view Element.
+     * 
+     * @param display_commit Commit to display the information of.
+     * @return ftxui::Element 
+     */
     static ftxui::Element renderInfoView(const cpplibostree::Commit& display_commit);
 };
 
@@ -46,6 +52,11 @@ public:
 public:
     BranchBoxManager(cpplibostree::OSTreeRepo& repo, std::unordered_map<std::string, bool>& visible_branches);
     
+    /**
+     * @brief Build the branch box Element.
+     * 
+     * @return ftxui::Element 
+     */
     ftxui::Element branchBoxRender();
 };
 
@@ -74,17 +85,36 @@ public:
     ftxui::Component apply_button; // must be set from OSTreeTUI
 
 public:
+    /**
+     * @brief Constructor for the Promotion Manager.
+     * 
+     * @warning The branch_selection and apply_button have to be set
+     * using the respective set-methods AFTER construction, as they
+     * have to be constructed in the OSTreeTUI::main
+     */
     ContentPromotionManager();
 
+    /// Setter
     void setBranchRadiobox(ftxui::Component radiobox);
+    /// Setter
     void setApplyButton(ftxui::Component button);
 
-    /// Warning: branch_selection & apply_button have to be set first
+    /**
+     * @brief Build the promotion view Component
+     * 
+     * @warning branch_selection & apply_button have to be set first (checked through assert)
+     * @return ftxui::Component 
+     */
     ftxui::Component composePromotionComponent();
 
     /// renders the promotion command resulting from the current user settings (ostree commit ...) 
     ftxui::Elements renderPromotionCommand(cpplibostree::OSTreeRepo& ostree_repo, const std::string& selected_commit_hash);
 
-    /// Warning: branch_selection & apply_button have to be set first
+    /**
+     * @brief Build the promotion view Element
+     * 
+     * @warning branch_selection & apply_button have to be set first (checked through assert)
+     * @return ftxui::Element
+     */
     ftxui::Element renderPromotionView(cpplibostree::OSTreeRepo& ostree_repo, cpplibostree::Commit& display_commit);
 };

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -26,8 +26,6 @@ public:
     ftxui::Component tab_selection;
     ftxui::Component tab_content;
 
-    ftxui::Component top_text_box;
-
     // because the combination of all interchangeable views is very simple,
     // we can (in contrast to the other ones) render this one immediately
     ftxui::Component manager_renderer;

--- a/src/core/manager.hpp
+++ b/src/core/manager.hpp
@@ -84,6 +84,7 @@ public:
     ftxui::Component apply_button; // must be set from OSTreeTUI
 
     // tool-tips
+    bool show_tooltips{true};
     ftxui::Component tool_tips_comp;
     const std::vector<std::string> tool_tip_strings = {
         "Branch to promote the Commit to.",
@@ -100,7 +101,7 @@ public:
      * using the respective set-methods AFTER construction, as they
      * have to be constructed in the OSTreeTUI::main
      */
-    ContentPromotionManager();
+    ContentPromotionManager(bool show_tooltips = true);
 
     /// Setter
     void setBranchRadiobox(ftxui::Component radiobox);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,9 @@ int main(int argc, const char** argv) {
 	std::string repo = args.at(0);
 	// -r, --refs
 	std::vector<std::string> startupBranches = getArgOptions(args, {"-r", "--refs"});
-	
+	// -n, --no-tooltips
+	bool hideTooltips = argExists(args, "-n") || argExists(args, "--no-tooltips");
+
 	// OSTree TUI
-	return OSTreeTUI::main(repo, startupBranches);
+	return OSTreeTUI::main(repo, startupBranches, !hideTooltips);
 }

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -287,20 +287,6 @@ namespace cpplibostree {
         return branches_str;
     }
 
-    std::string exec(const char* cmd) {
-            std::array<char, 128> buffer;
-            std::string result;
-            std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
-            if (!pipe) {
-                throw std::runtime_error("popen() failed!");
-            }
-            while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
-                result += buffer.data();
-                result += " ";
-            }
-            return result;
-        }
-
     /// TODO This implementation is dirty, it should not rely on the ostree CLI
     bool OSTreeRepo::promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject, bool keepMetadata) {
         if (hash.size() <= 0 || newRef.size() <= 0) {

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -287,8 +287,43 @@ namespace cpplibostree {
         return branches_str;
     }
 
-    bool promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject) {
-        return false;
+    std::string exec(const char* cmd) {
+            std::array<char, 128> buffer;
+            std::string result;
+            std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd, "r"), pclose);
+            if (!pipe) {
+                throw std::runtime_error("popen() failed!");
+            }
+            while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe.get()) != nullptr) {
+                result += buffer.data();
+                result += " ";
+            }
+            return result;
+        }
+
+    /// TODO This implementation is dirty, it should not rely on the ostree CLI
+    bool OSTreeRepo::promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject, bool keepMetadata) {
+        if (hash.size() <= 0 || newRef.size() <= 0) {
+            return false;
+        }
+        
+        auto repo   = " --repo=" + repo_path;
+        auto branch = " -b " + newRef;
+        auto subj   = (newSubject.size() <= 0
+                            ? ""
+                            : " -s " + newSubject);
+        auto meta   = (keepMetadata
+                            ? ""
+                            : " --keep-metadata");
+        auto tree   = " --tree=ref=" + hash;
+        
+        std::string command = "ostree commit" + repo + branch + newRef + subj + meta + tree;
+        std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(command.c_str(), "r"), pclose);
+        
+        if (!pipe) {
+            return false;
+        }
+        return true;
     }
 
 } // namespace cpplibostree

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -287,4 +287,8 @@ namespace cpplibostree {
         return branches_str;
     }
 
+    bool promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject) {
+        return false;
+    }
+
 } // namespace cpplibostree

--- a/src/util/cpplibostree.cpp
+++ b/src/util/cpplibostree.cpp
@@ -300,7 +300,7 @@ namespace cpplibostree {
         command += " -b " + newRef;
         command += (newSubject.size() <= 0
                             ? ""
-                            : " -s " + newSubject);
+                            : " -s \"" + newSubject + "\"");
         command += (keepMetadata
                             ? ""
                             : " --keep-metadata");

--- a/src/util/cpplibostree.hpp
+++ b/src/util/cpplibostree.hpp
@@ -149,7 +149,7 @@ namespace cpplibostree {
          * @return true on success
          * @return false on failed promotion
          */
-        bool promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject = "", bool keepMetadata = false);
+        bool promoteCommit(const std::string& hash, const std::string& newRef, const std::vector<std::string> addMetadataStrings, const std::string& newSubject = "", bool keepMetadata = false);
 
     private:
         /**

--- a/src/util/cpplibostree.hpp
+++ b/src/util/cpplibostree.hpp
@@ -136,6 +136,20 @@ namespace cpplibostree {
          */
         CommitList parseCommitsAllBranches();
 
+        // read & write access to OSTree repo:
+
+        /**
+         * @brief Promotes a commit to another branch. Similar to: 
+         * `ostree commit --repo=repo -b newRef -s newSubject --tree=ref=hash`
+         * 
+         * @param hash hash of the commit to promote
+         * @param newRef branch to promote to
+         * @param newSubject new commit subject, it needed
+         * @return true on success
+         * @return false on failed promotion
+         */
+        bool promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject = "");
+
     private:
         /**
          * @brief Get all branches as a single string, separated by spaces.

--- a/src/util/cpplibostree.hpp
+++ b/src/util/cpplibostree.hpp
@@ -145,10 +145,11 @@ namespace cpplibostree {
          * @param hash hash of the commit to promote
          * @param newRef branch to promote to
          * @param newSubject new commit subject, it needed
+         * @param keepMetadata should new commit keep metadata of old commit
          * @return true on success
          * @return false on failed promotion
          */
-        bool promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject = "");
+        bool promoteCommit(const std::string& hash, const std::string& newRef, const std::string& newSubject = "", bool keepMetadata = false);
 
     private:
         /**


### PR DESCRIPTION
PR for [Issue #11](https://github.com/AP-Sensing/ostree-tui/issues/11)

# Content Promotion
This PR brings **Content Promotion** to the **OSTree TUI**.

## Basics
To make it fit into the UI, I reworked the basic layout to use **Tabs** on the left halve of the screen (where previously the branch filter and commit info was). This also allows for an easy addition of future features in new tabs, while creating a neat and modern look for the UI. In addition to that, the *Footer* is now able to display notifications to the user. 

## Implementation
The *Manager* is now split into 4 parts, as it is now only responsible for putting the 3 new tabs together (instead of being responsible for all that happens within this view). The 3 tabs each got their own class, to store data and logical components:
- the *CommitInfoManager*,
- the *BranchBoxManager*,
- and the *ContentPromotionManager*.

## ToDos
- [x] Restructure UI layout -> Tabs
- [x] Add content promotion to UI
- [x] Implement content promotion in `cpplibostree`
- [x] Code Cleanup
- [ ] Make content promotion direct `libostree` access (not CLI)

*@COM8  [suggestions](https://github.com/AP-Sensing/ostree-tui/pull/12#issuecomment-2144581861):*
- [x] Add Tooltips
- [x] Improve promotion-tab navigation
- [x] Fix UI component size & flex
- [x] Rethink boxed layout
