### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,10 +1,6 @@
-name: CMake on multiple platforms
+name: OSTree-TUI CI
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, workflow_dispatch, pull_request]
 
 jobs:
   fedora-clang:

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -7,11 +7,10 @@ on:
     branches: [ "main" ]
 
 jobs:
-  fedora-gcc-openssl:
+  fedora-clang:
     strategy:
       matrix:
         container: ["fedora:latest"]
-        # systemCurl: [ON, OFF]
         buildType: [Debug, Release]
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
@@ -29,7 +28,38 @@ jobs:
         CPR_BUILD_TESTS: OFF # ON
         CPR_BUILD_TESTS_SSL: OFF # ON
         CPR_FORCE_OPENSSL_BACKEND: ON
-        USE_SYSTEM_CURL: ${{ matrix.systemCurl }}
+        USE_SYSTEM_CURL: OFF
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ github.workspace }}/build
+        source-dir: ${{ github.workspace }}
+        cc: clang
+        cxx: clang++
+        build-type: Release
+        run-test: false # true
+        ctest-options: ${{ env.CTEST_OPTIONS }}
+
+  fedora-gcc:
+    strategy:
+      matrix:
+        container: ["fedora:latest"]
+        buildType: [Debug, Release]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+    - name: Update package list
+      run: dnf update -y
+    - name: Install Dependencies
+      run: |
+        dnf install -y gcc-c++ clang git gcc gdb make openssl-devel libcurl-devel cmake automake autoconf
+        dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Build" # & Test"
+      env:
+        CPR_BUILD_TESTS: OFF # ON
+        CPR_BUILD_TESTS_SSL: OFF # ON
+        CPR_FORCE_OPENSSL_BACKEND: ON
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{ github.workspace }}/build

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -19,8 +19,8 @@ jobs:
       run: dnf update -y
     - name: Install Dependencies
       run: |
-        dnf install -y gcc-c++ clang git gcc gdb make openssl-devel libcurl-devel cmake automake autoconf
-        dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y gcc-c++ clang git gcc gdb make cmake automake autoconf
+        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
     - name: Checkout
       uses: actions/checkout@v3
     - name: "Build" # & Test"
@@ -51,8 +51,8 @@ jobs:
       run: dnf update -y
     - name: Install Dependencies
       run: |
-        dnf install -y gcc-c++ clang git gcc gdb make openssl-devel libcurl-devel cmake automake autoconf
-        dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y gcc-c++ clang git gcc gdb make cmake automake autoconf
+        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
     - name: Checkout
       uses: actions/checkout@v3
     - name: "Build" # & Test"
@@ -69,3 +69,33 @@ jobs:
         build-type: ${{ matrix.buildType }}
         run-test: false # true
         ctest-options: ${{ env.CTEST_OPTIONS }}
+
+  clang-tidy:
+    strategy:
+      matrix:
+        container: ["fedora:latest"]
+        buildType: [Debug]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+    - name: Update package list
+      run: sudo dnf update -y
+    - name: Install dependencies
+      run: |
+        sudo dnf install -y cmake git gcc clang ninja-build automake autoconf
+        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y clang-tools-extra
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Build Debug" # & Test"
+      env:
+        CPR_BUILD_TESTS: OFF # ON
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{github.workspace}}/build
+        source-dir: ${{github.workspace}}
+        cc: clang
+        cxx: clang++
+        build-type: ${{ matrix.buildType }}
+        run-test: false
+        configure-options: -DCPR_ENABLE_LINTING=ON

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -15,10 +15,9 @@ jobs:
   fedora-clang:
     strategy:
       matrix:
-        container: ["fedora:latest"]
         buildType: [Debug, Release]
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    container: "fedora:latest"
     steps:
     - name: Update package list
       run: dnf update -y
@@ -44,10 +43,9 @@ jobs:
   fedora-gcc:
     strategy:
       matrix:
-        container: ["fedora:latest"]
         buildType: [Debug, Release]
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    container: "fedora:latest"
     steps:
     - name: Update package list
       run: dnf update -y
@@ -100,12 +98,8 @@ jobs:
         ctest-options: ${{ env.CTEST_OPTIONS }}
 
   clang-tidy:
-    strategy:
-      matrix:
-        container: ["fedora:latest"]
-        buildType: [Debug]
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    container: "fedora:latest"
     steps:
     - name: Update package list
       run: sudo dnf update -y
@@ -124,13 +118,13 @@ jobs:
         source-dir: ${{github.workspace}}
         cc: clang
         cxx: clang++
-        build-type: ${{ matrix.buildType }}
+        build-type: Debug
         run-test: false
         configure-options: -DCPR_ENABLE_LINTING=ON
 
   clang-format:
     runs-on: ubuntu-latest
-    container: fedora:latest
+    container: "fedora:latest"
     steps:
     - name: Update package list
       run: sudo dnf update -y
@@ -142,12 +136,8 @@ jobs:
       run: bash scripts/check_clang_format.sh
 
   cppcheck:
-    strategy:
-      matrix:
-        container: ["fedora:latest"]
-        buildType: [Release]
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    container: "fedora:latest"
     steps:
     - name: Update package list
       run: dnf update -y
@@ -168,5 +158,5 @@ jobs:
         source-dir: ${{ github.workspace }}
         cc: gcc
         cxx: g++
-        build-type: ${{ matrix.buildType }}
+        build-type: Release
         run-test: false

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -95,3 +95,16 @@ jobs:
         build-type: ${{ matrix.buildType }}
         run-test: false
         configure-options: -DCPR_ENABLE_LINTING=ON
+
+  clang-format:
+    runs-on: ubuntu-latest
+    container: fedora:latest
+    steps:
+    - name: Update package list
+      run: sudo dnf update -y
+    - name: Install clang-format
+      run: sudo dnf install -y clang-tools-extra
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check format
+      run: bash scripts/check_clang_format.sh

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -26,9 +26,6 @@ jobs:
     - name: "Build" # & Test"
       env:
         CPR_BUILD_TESTS: OFF # ON
-        CPR_BUILD_TESTS_SSL: OFF # ON
-        CPR_FORCE_OPENSSL_BACKEND: ON
-        USE_SYSTEM_CURL: OFF
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{ github.workspace }}/build
@@ -58,8 +55,6 @@ jobs:
     - name: "Build" # & Test"
       env:
         CPR_BUILD_TESTS: OFF # ON
-        CPR_BUILD_TESTS_SSL: OFF # ON
-        CPR_FORCE_OPENSSL_BACKEND: ON
       uses: ashutoshvarma/action-cmake-build@master
       with:
         build-dir: ${{ github.workspace }}/build
@@ -112,3 +107,33 @@ jobs:
       uses: actions/checkout@v3
     - name: Check format
       run: bash scripts/check_clang_format.sh
+
+  cppcheck:
+    strategy:
+      matrix:
+        container: ["fedora:latest"]
+        buildType: [Release]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+    - name: Update package list
+      run: dnf update -y
+    - name: Install Dependencies
+      run: |
+        sudo dnf install -y gcc-c++ clang git gcc gdb make cmake automake autoconf
+        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y cppcheck
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Build"
+      env:
+        CPR_BUILD_TESTS: OFF
+        CPR_ENABLE_CPPCHECK: ON
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ github.workspace }}/build
+        source-dir: ${{ github.workspace }}
+        cc: gcc
+        cxx: g++
+        build-type: ${{ matrix.buildType }}
+        run-test: false

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,3 +1,7 @@
+# Github CI config
+# Inspired by https://github.com/libcpr/cpr/blob/master/.github/workflows/ci.yml
+# Runs: clang format check, g++ & clang, release & debug, on Fedora
+
 name: OSTree-TUI CI
 
 on: [push, workflow_dispatch, pull_request]

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -6,6 +6,11 @@ name: OSTree-TUI CI
 
 on: [push, workflow_dispatch, pull_request]
 
+env:
+  # standard dependencies for building & project
+  BUILD_DEPENDENCIES: "gcc-c++ clang git gcc gdb make cmake automake autoconf"
+  OSTREE_TUI_DEPENDENCIES: "glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel"
+
 jobs:
   fedora-clang:
     strategy:
@@ -19,8 +24,8 @@ jobs:
       run: dnf update -y
     - name: Install Dependencies
       run: |
-        sudo dnf install -y gcc-c++ clang git gcc gdb make cmake automake autoconf
-        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y ${{ env.BUILD_DEPENDENCIES }}
+        sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: "Build" # & Test"
@@ -48,8 +53,8 @@ jobs:
       run: dnf update -y
     - name: Install Dependencies
       run: |
-        sudo dnf install -y gcc-c++ clang git gcc gdb make cmake automake autoconf
-        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y ${{ env.BUILD_DEPENDENCIES }}
+        sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: "Build" # & Test"
@@ -77,9 +82,8 @@ jobs:
       run: sudo dnf update -y
     - name: Install dependencies
       run: |
-        sudo dnf install -y cmake git gcc clang ninja-build automake autoconf
-        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
-        sudo dnf install -y clang-tools-extra
+        sudo dnf install -y cmake git gcc clang ninja-build automake autoconf clang-tools-extra
+        sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
     - name: Checkout
       uses: actions/checkout@v3
     - name: "Build Debug" # & Test"
@@ -120,8 +124,8 @@ jobs:
       run: dnf update -y
     - name: Install Dependencies
       run: |
-        sudo dnf install -y gcc-c++ clang git gcc gdb make cmake automake autoconf
-        sudo dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+        sudo dnf install -y ${{ env.BUILD_DEPENDENCIES }}
+        sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
         sudo dnf install -y cppcheck
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,41 @@
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  fedora-gcc-openssl:
+    strategy:
+      matrix:
+        container: ["fedora:latest"]
+        # systemCurl: [ON, OFF]
+        buildType: [Debug, Release]
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+    - name: Update package list
+      run: dnf update -y
+    - name: Install Dependencies
+      run: |
+        dnf install -y gcc-c++ clang git gcc gdb make openssl-devel libcurl-devel cmake automake autoconf
+        dnf install -y glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Build" # & Test"
+      env:
+        CPR_BUILD_TESTS: OFF # ON
+        CPR_BUILD_TESTS_SSL: OFF # ON
+        CPR_FORCE_OPENSSL_BACKEND: ON
+        USE_SYSTEM_CURL: ${{ matrix.systemCurl }}
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ github.workspace }}/build
+        source-dir: ${{ github.workspace }}
+        cc: gcc
+        cxx: g++
+        build-type: ${{ matrix.buildType }}
+        run-test: false # true
+        ctest-options: ${{ env.CTEST_OPTIONS }}

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -70,6 +70,35 @@ jobs:
         run-test: false # true
         ctest-options: ${{ env.CTEST_OPTIONS }}
 
+  fedora-gcc-sanitizer:
+    strategy:
+      matrix:
+        buildType: [UdefSan, LeakSan, AddrSan, ThreadSan]
+    runs-on: ubuntu-latest
+    container: "fedora:latest"
+    steps:
+    - name: Update package list
+      run: dnf update -y
+    - name: Install Dependencies
+      run: |
+        sudo dnf install -y ${{ env.BUILD_DEPENDENCIES }}
+        sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
+        sudo dnf install -y libasan libubsan liblsan libtsan
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: "Build" # & Test
+      env:
+        CPR_BUILD_TESTS: OFF
+      uses: ashutoshvarma/action-cmake-build@master
+      with:
+        build-dir: ${{ github.workspace }}/build
+        source-dir: ${{ github.workspace }}
+        cc: gcc
+        cxx: g++
+        build-type: ${{ matrix.buildType }}
+        run-test: false # true
+        ctest-options: ${{ env.CTEST_OPTIONS }}
+
   clang-tidy:
     strategy:
       matrix:
@@ -82,7 +111,7 @@ jobs:
       run: sudo dnf update -y
     - name: Install dependencies
       run: |
-        sudo dnf install -y cmake git gcc clang ninja-build automake autoconf clang-tools-extra
+        sudo dnf install -y cmake git gcc-c++ clang ninja-build automake autoconf clang-tools-extra
         sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -138,26 +138,14 @@ jobs:
 
   cppcheck:
     runs-on: ubuntu-latest
-    container: "fedora:latest"
     steps:
-    - name: Update package list
-      run: dnf update -y
-    - name: Install Dependencies
-      run: |
-        sudo dnf install -y ${{ env.BUILD_DEPENDENCIES }}
-        sudo dnf install -y ${{ env.OSTREE_TUI_DEPENDENCIES }}
-        sudo dnf install -y cppcheck
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: "Build"
-      env:
-        CPR_BUILD_TESTS: OFF
-        CPR_ENABLE_CPPCHECK: ON
-      uses: ashutoshvarma/action-cmake-build@master
+    - uses: actions/checkout@v2
+    - name: "Run cppcheck"
+      uses: deep5050/cppcheck-action@main
       with:
-        build-dir: ${{ github.workspace }}/build
-        source-dir: ${{ github.workspace }}
-        cc: gcc
-        cxx: g++
-        build-type: Release
-        run-test: false
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        check_library: enable
+        enable: warning,style,performance,missingInclude
+        output_file: cppcheck_report.txt
+    - name: "Print report"
+      run: cat cppcheck_report.txt

--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -7,6 +7,7 @@ name: OSTree-TUI CI
 on: [push, workflow_dispatch, pull_request]
 
 env:
+  # ctest not used yet
   # standard dependencies for building & project
   BUILD_DEPENDENCIES: "gcc-c++ clang git gcc gdb make cmake automake autoconf"
   OSTREE_TUI_DEPENDENCIES: "glib2-devel gtk-doc ostree-devel libtool bison liblzf e2fsprogs-devel xz-devel gpgme-devel fuse-devel"
@@ -38,7 +39,7 @@ jobs:
         cxx: clang++
         build-type: Release
         run-test: false # true
-        ctest-options: ${{ env.CTEST_OPTIONS }}
+        # ctest-options: ${{ env.CTEST_OPTIONS }}
 
   fedora-gcc:
     strategy:
@@ -66,7 +67,7 @@ jobs:
         cxx: g++
         build-type: ${{ matrix.buildType }}
         run-test: false # true
-        ctest-options: ${{ env.CTEST_OPTIONS }}
+        # ctest-options: ${{ env.CTEST_OPTIONS }}
 
   fedora-gcc-sanitizer:
     strategy:
@@ -95,7 +96,7 @@ jobs:
         cxx: g++
         build-type: ${{ matrix.buildType }}
         run-test: false # true
-        ctest-options: ${{ env.CTEST_OPTIONS }}
+        # ctest-options: ${{ env.CTEST_OPTIONS }}
 
   clang-tidy:
     runs-on: ubuntu-latest

--- a/scripts/check_clang_format.sh
+++ b/scripts/check_clang_format.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Based on: https://gist.github.com/leilee/1d0915a583f8f29414cc21cd86e7151b
+# Checks if all files are formatted based on the clang-format formatting rules.
+# Execute as follows:
+# ./scripts/check_clang_format.sh src
+
+printf "📑  Checking if your code fulfills all clang-format rules...\n"
+
+RET_CODE=0
+
+function format() {
+    for f in $(find $@ -name '*.h' -or -name '*.hpp' -or -name '*.c' -or -name '*.cpp'); do 
+        clang-format -i --dry-run --Werror --style=file ${f};
+        ret=$?
+        if [ $ret -ne 0 ]; then
+            RET_CODE=$ret
+        fi
+    done
+
+    echo "~~~ $@ directory checked ~~~";
+}
+
+# Check all of the arguments first to make sure they're all directories
+for dir in "$@"; do
+    if [ ! -d "${dir}" ]; then
+        echo "${dir} is not a directory";
+    else
+        format ${dir};
+    fi
+done
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+if [ $RET_CODE -eq 0 ]; then
+    printf "✅ ${GREEN}Everything up to standard :party: ${NC}\n"
+else
+    printf "❌ ${RED}Not up to formatting standard :sad_face: ${NC}\n"
+    echo "Try running run_clang_format.sh to format all files."
+fi
+
+exit $RET_CODE

--- a/scripts/run_clang_format.sh
+++ b/scripts/run_clang_format.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Based on: https://gist.github.com/leilee/1d0915a583f8f29414cc21cd86e7151b
+# Run from the project root directory as follows:
+# ./scripts/run_clang_format.sh tests
+
+printf "📝  Running clang-format...\n"
+
+function format() {
+    for f in $(find $@ -name '*.h' -or -name '*.hpp' -or -name '*.c' -or -name '*.cpp'); do 
+        echo "format ${f}";
+        clang-format -i --style=file ${f};
+    done
+
+    echo "~~~ $@ directory formatted ~~~";
+}
+
+# Check all of the arguments first to make sure they're all directories
+for dir in "$@"; do
+    if [ ! -d "${dir}" ]; then
+        echo "${dir} is not a directory";
+    else
+        format ${dir};
+    fi
+done
+
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+printf "✅ ${GREEN}Done. All files were formatted (if required).${NC}\n"


### PR DESCRIPTION
Defines a Github CI, with the following requirements (see [Issue #18](https://github.com/AP-Sensing/ostree-tui/issues/18)):
- [x] Add a CI run that builds using gcc as compiler a debug build
- [x] Add a CI run that builds using gcc as compiler a release build
- [x] Add a CI run that builds using clang as compiler a debug build
- [x] Add a CI run that builds using clang as compiler a release build
- [x] Run a clang-tidy build in debug
- [x] Run a clang-format check
- [x] All CI runs have to be run under [`fedora:latest`](https://hub.docker.com/_/fedora)
- [x] Add cppcheck
- [x] Investigate if CI builds using sanitizers make sense e.g. thread-, address-, undefined behaviour-, ...